### PR TITLE
Use max stops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.xlsx
+__pycache__/

--- a/nt_parser.py
+++ b/nt_parser.py
@@ -269,7 +269,7 @@ def convert_nested_jsons_to_flatted_jsons(origin_results: list,
     return flatted_results
 
 
-def results_to_excel(results, max_stops: int = 1):
+def results_to_excel(results):
     if len(results) == 0:
         print('No results at all, finished.')
     else:

--- a/use_aa.py
+++ b/use_aa.py
@@ -46,5 +46,6 @@ if __name__ == '__main__':
     airbounds = filter_models(airbounds, price_filter)
     results = []
     for x in airbounds:
-        results.extend(x.to_flatted_list())
-    results_to_excel(results, max_stops=max_stops)
+        if x.stops <= max_stops:
+            results.extend(x.to_flatted_list())
+    results_to_excel(results)

--- a/use_ac.py
+++ b/use_ac.py
@@ -44,5 +44,6 @@ if __name__ == '__main__':
     airbounds = filter_models(airbounds, price_filter)
     results = []
     for x in airbounds:
-        results.extend(x.to_flatted_list())
-    results_to_excel(results, max_stops=max_stops)
+        if x.stops <= max_stops:
+            results.extend(x.to_flatted_list())
+    results_to_excel(results)


### PR DESCRIPTION
`max_stops` was not used in `results_to_excel` function, filtering wasn't working. 
This PR adds a simply filtering logic with `max_stops` before results were sent.