### PR TITLE
Fix wrong type of miles in cron processor

### DIFF
--- a/cron/process.py
+++ b/cron/process.py
@@ -25,11 +25,11 @@ def match_query(air_bound: AirBound, q: FlightQuery):
             continue
         if q.num_passengers and price.quota < q.num_passengers:
             continue
-        if air_bound.engine.upper() == "AA" and price.miles <= q.max_aa_points:
+        if air_bound.engine.upper() == "AA" and price.excl_miles <= q.max_aa_points:
             return True
-        if air_bound.engine.upper() == "AC" and price.miles <= q.max_ac_points:
+        if air_bound.engine.upper() == "AC" and price.excl_miles <= q.max_ac_points:
             return True
-        if air_bound.engine.upper() == "DL" and price.miles <= q.max_dl_points:
+        if air_bound.engine.upper() == "DL" and price.excl_miles <= q.max_dl_points:
             return True
 
     # Did not find any price in selected cabin.


### PR DESCRIPTION
* price.miles is a str and when running in cron job, the <= operation failed because str can't be compared with decimal.
* Instead we should use excl_miles